### PR TITLE
chore(ci): add deploy workflow (manual-run)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy SLY Theme
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rsync Deploy
+        uses: burnett01/rsync-deployments@6.0.0
+        with:
+          switches: -avzr --delete --exclude='.git' --exclude='.github' --exclude='node_modules' --exclude='*.map'
+          path: .
+          remote_path: ${{ secrets.REMOTE_PATH_PROD }}
+          remote_host: ${{ secrets.SSH_HOST }}
+          remote_user: ${{ secrets.SSH_USER }}
+          remote_key: ${{ secrets.SSH_KEY }}
+          remote_port: ${{ secrets.SSH_PORT }}
+
+      - name: Purge cache
+        uses: appleboy/ssh-action@v1.2.0
+        continue-on-error: true
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            cd "${{ secrets.WP_PATH_PROD }}"
+            wp cache flush

--- a/README.md
+++ b/README.md
@@ -10,3 +10,16 @@ This repository contains the initial skeleton for the SLY theme.
 ## Hero Video
 
 The front page expects a hero video located at `assets/img/sly-main.mp4`. Place your MP4 file there.
+
+## CI/CD
+
+Deployment uses a manual GitHub Actions workflow to sync the theme to the production server.
+
+Required repository secrets:
+
+- `SSH_HOST`
+- `SSH_USER`
+- `SSH_KEY` (private key)
+- `SSH_PORT` (22)
+- `REMOTE_PATH_PROD` (e.g. /home/slyconcept.com/public_html/wp-content/themes/sly)
+- `WP_PATH_PROD` (e.g. /home/slyconcept.com/public_html)


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy theme over SSH/rsync
- document required CI/CD secrets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d2343e88832ca047d149cdd1560c